### PR TITLE
Auto-naming + Template Building experiments

### DIFF
--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/ClassToTypeMappings.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/ClassToTypeMappings.kt
@@ -9,7 +9,30 @@ import com.amazonaws.services.autoscaling.model.CreateLaunchConfigurationRequest
 import com.amazonaws.services.autoscaling.model.CreateLaunchConfigurationResult
 import com.amazonaws.services.identitymanagement.model.*
 import com.amazonaws.services.iot.model.CreatePolicyResult
+import uy.kohesive.iac.model.aws.helpers.getPolicyNameFromArn
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction1
+
+object AutoNaming {
+
+    private val requestClassesToDefiningPropertyGetters: Map<KClass<out AmazonWebServiceRequest>, KFunction1<*, String>> = mapOf(
+        CreateRoleRequest::class                to CreateRoleRequest::getRoleName,
+        CreatePolicyRequest::class              to CreatePolicyRequest::getPolicyName,
+        CreateInstanceProfileRequest::class     to CreateInstanceProfileRequest::getInstanceProfileName,
+        CreateAutoScalingGroupRequest::class    to CreateAutoScalingGroupRequest::getAutoScalingGroupName,
+        CreateLaunchConfigurationRequest::class to CreateLaunchConfigurationRequest::getLaunchConfigurationName,
+        AddRoleToInstanceProfileRequest::class  to AddRoleToInstanceProfileRequest::getInstanceProfileName,
+        AttachRolePolicyRequest::class          to AttachRolePolicyRequest::getPolicyNameFromArn
+    )
+
+    fun getName(request: AmazonWebServiceRequest): String? {
+        val getter = requestClassesToDefiningPropertyGetters[request::class]
+            ?: throw java.lang.IllegalArgumentException("Unknown request type: ${ request::class.java.simpleName }")
+
+        return (getter as KFunction1<AmazonWebServiceRequest, String>).invoke(request)
+    }
+
+}
 
 enum class AwsTypes(val type: String,
                     val requestClass: KClass<out AmazonWebServiceRequest>,
@@ -26,9 +49,9 @@ enum class AwsTypes(val type: String,
     companion object {
         private val typeStringToEnum = enumValues<AwsTypes>().map { it.type to it }.toMap()
         private val typeClassToEnum  = enumValues<AwsTypes>()
-                .map { item -> (item.relatedClasses.toList() + listOf(item.requestClass, item.resultClass, item.stateClass)).map { it to item } }
-                .flatten()
-                .toMap()
+            .map { item -> (item.relatedClasses.toList() + listOf(item.requestClass, item.resultClass, item.stateClass)).map { it to item } }
+            .flatten()
+            .toMap()
 
         private val requestClasses: Set<KClass<out AmazonWebServiceRequest>> = enumValues<AwsTypes>().map { it.requestClass }.toSet()
 

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/DeferredAmazonIdentityManagement.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/DeferredAmazonIdentityManagement.kt
@@ -8,13 +8,11 @@ import uy.kohesive.iac.model.aws.proxy.makeProxy
 class DeferredAmazonIdentityManagement(val context: IacContext) : AbstractAmazonIdentityManagement(), AmazonIdentityManagement {
 
     override fun attachRolePolicy(request: AttachRolePolicyRequest): AttachRolePolicyResult {
-        // TODO: do we need to do anything there? I think not — we've registered the request already
-        return AttachRolePolicyResult()
+        return with (context) { AttachRolePolicyResult().registerWithSameNameAs(request) }
     }
 
     override fun addRoleToInstanceProfile(request: AddRoleToInstanceProfileRequest): AddRoleToInstanceProfileResult {
-        // TODO: do we need to do anything there? I think not — we've registered the request already
-        return AddRoleToInstanceProfileResult()
+        return with (context) { AddRoleToInstanceProfileResult().registerWithSameNameAs(request) }
     }
 
     override fun createInstanceProfile(request: CreateInstanceProfileRequest): CreateInstanceProfileResult {
@@ -22,7 +20,7 @@ class DeferredAmazonIdentityManagement(val context: IacContext) : AbstractAmazon
             CreateInstanceProfileResult().withInstanceProfile(
                 makeProxy<CreateInstanceProfileRequest, InstanceProfile>(
                     context       = this@with,
-                    id            = getId(request) ?: throw IllegalStateException(),
+                    sourceName    = getNameStrict(request),
                     requestObject = request,
                     copyFromReq   = mapOf(
                         CreateInstanceProfileRequest::getInstanceProfileName to InstanceProfile::getInstanceProfileName,
@@ -39,7 +37,7 @@ class DeferredAmazonIdentityManagement(val context: IacContext) : AbstractAmazon
             CreateRoleResult().withRole(
                 makeProxy<CreateRoleRequest, Role>(
                     context       = this@with,
-                    id            = getId(request) ?: throw IllegalStateException(),
+                    sourceName    = getNameStrict(request),
                     requestObject = request,
                     copyFromReq   = mapOf(
                         CreateRoleRequest::getAssumeRolePolicyDocument to Role::getAssumeRolePolicyDocument,
@@ -57,7 +55,7 @@ class DeferredAmazonIdentityManagement(val context: IacContext) : AbstractAmazon
             CreatePolicyResult().withPolicy(
                 makeProxy<CreatePolicyRequest, Policy>(
                     context       = this@with,
-                    id            = getId(request) ?: throw IllegalStateException(),
+                    sourceName    = getNameStrict(request),
                     requestObject = request,
                     copyFromReq   = mapOf(
                         CreatePolicyRequest::getDescription to Policy::getDescription,

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/IacContext.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/IacContext.kt
@@ -15,7 +15,8 @@ open class IacContext(
         val namingStrategy: IacContextNamingStrategy = IacSimpleEnvPrefixNamingStrategy(),
         init: IacContext.() -> Unit = {}
 ) : KohesiveIdentifiable, Ec2Enabled, IamRoleEnabled, AutoScalingEnabled {
-    override val objectsToIds = IdentityHashMap<Any, String>()
+
+    override val objectsToNames= IdentityHashMap<Any, String>()
 
     val variables: MutableMap<String, ParameterizedValue> = hashMapOf()
     val mappings: MutableMap<String, MappedValues> = hashMapOf()

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/KohesiveIdentifiable.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/KohesiveIdentifiable.kt
@@ -1,27 +1,27 @@
 package uy.kohesive.iac.model.aws
 
 import com.amazonaws.AmazonWebServiceRequest
-import com.amazonaws.AmazonWebServiceResult
-import com.amazonaws.ResponseMetadata
 import java.util.*
 
 interface KohesiveIdentifiable {
-    val objectsToIds: IdentityHashMap<Any, String>
 
-    fun getId(obj: Any): String?  = objectsToIds[obj]
+    val objectsToNames: IdentityHashMap<Any, String>
 
-    fun <T : AmazonWebServiceRequest> T.withKohesiveId(id: String): T = apply {
-        objectsToIds[this@withKohesiveId] = id
+    fun getName(obj: Any) = objectsToNames[obj]
+    fun getNameStrict(obj: Any) = objectsToNames[obj] ?: throw IllegalStateException("Unknown object $obj")
+
+    fun <T : Any> T.registerWithName(name: String): T = apply {
+        objectsToNames[this@registerWithName] = name
     }
 
-    fun <K: ResponseMetadata, T : AmazonWebServiceResult<out K>> T.withKohesiveId(id: String): T = apply {
-        objectsToIds[this@withKohesiveId] = id
+    fun <T : Any> T.registerWithSameNameAs(another: Any): T = apply {
+        objectsToNames[this@registerWithSameNameAs] = getNameStrict(another)
     }
 
-    // TODO: any way to avoid Any?  what types are possible here?
-    fun <T : Any> T.withKohesiveId(id: String): T = apply {
-        objectsToIds[this@withKohesiveId] = id
+    fun <T : AmazonWebServiceRequest> T.registerWithAutoName(): T = apply {
+        registerWithName(AutoNaming.getName(this) ?: throw IllegalArgumentException("Unknown request"))
     }
+
 }
 
 interface TagAware<out T : Any> {

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/cloudformation/IAM.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/cloudformation/IAM.kt
@@ -1,0 +1,48 @@
+package uy.kohesive.iac.model.aws.cloudformation
+
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.services.identitymanagement.model.AddRoleToInstanceProfileRequest
+import com.amazonaws.services.identitymanagement.model.AttachRolePolicyRequest
+import com.amazonaws.services.identitymanagement.model.CreateInstanceProfileRequest
+import com.amazonaws.services.identitymanagement.model.CreatePolicyRequest
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+class IamInstanceProfilePropertiesBuilder : ResourcePropertiesBuilder<CreateInstanceProfileRequest> {
+    override val requestClazz = CreateInstanceProfileRequest::class
+
+    override fun buildResource(request: AmazonWebServiceRequest, relatedObjects: List<Any>) =
+        (request as CreateInstanceProfileRequest).let {
+            IamInstanceProfileProperties(
+                Path  = it.path ?: "/",
+                Roles = relatedObjects.filterIsInstance(AddRoleToInstanceProfileRequest::class.java).map {
+                    it.roleName
+                }
+            )
+        }
+}
+
+class IamPolicyResourcePropertiesBuilder : ResourcePropertiesBuilder<CreatePolicyRequest> {
+    override val requestClazz = CreatePolicyRequest::class
+
+    override fun buildResource(request: AmazonWebServiceRequest, relatedObjects: List<Any>) =
+        (request as CreatePolicyRequest).let {
+            IamPolicyResourceProperties(
+                PolicyName     = it.policyName,
+                PolicyDocument = jacksonObjectMapper().readTree(it.policyDocument),
+                Roles          = relatedObjects.filterIsInstance(AttachRolePolicyRequest::class.java).map {
+                    it.roleName
+                }
+            )
+        }
+}
+
+data class IamPolicyResourceProperties(
+    val PolicyName: String,
+    val PolicyDocument: Any,
+    val Roles: List<Any>?
+) : ResourceProperties
+
+data class IamInstanceProfileProperties(
+    val Path: String,
+    val Roles: List<Any>?
+) : ResourceProperties

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/cloudformation/ReferenceExploder.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/cloudformation/ReferenceExploder.kt
@@ -2,6 +2,8 @@ package uy.kohesive.iac.model.aws.cloudformation
 
 import uy.kohesive.iac.model.aws.proxy.createReference
 
+// TODO: ignore this for now
+
 class One(val value: Any)
 class Two(val value: Any)
 class Three(val value: Any)

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/cloudformation/ResourceBuilder.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/cloudformation/ResourceBuilder.kt
@@ -1,0 +1,24 @@
+package uy.kohesive.iac.model.aws.cloudformation
+
+import com.amazonaws.AmazonWebServiceRequest
+import uy.kohesive.iac.model.aws.AwsTypes
+import kotlin.reflect.KClass
+
+// TODO: I failed to use generics here :(
+object ResourcePropertyBuilders {
+
+    private val awsTypeToBuilder: Map<AwsTypes, ResourcePropertiesBuilder<*>> = mapOf(
+        AwsTypes.IamPolicy          to IamPolicyResourcePropertiesBuilder(),
+        AwsTypes.IamInstanceProfile to IamInstanceProfilePropertiesBuilder()
+    )
+
+    fun getBuilder(awsType: AwsTypes) = awsTypeToBuilder[awsType]
+
+}
+
+interface CloudFormationResourceProperties
+
+interface ResourcePropertiesBuilder<T : AmazonWebServiceRequest> {
+    val requestClazz: KClass<T>
+    fun buildResource(request: AmazonWebServiceRequest, relatedObjects: List<Any>): ResourceProperties
+}

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/contexts/AutoScaling.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/contexts/AutoScaling.kt
@@ -11,14 +11,6 @@ interface AutoScalingIdentifiable : KohesiveIdentifiable, TagAware<Tag> {
 
     override fun createTag(key: String, value: String): Tag = Tag().withKey(key).withValue(value)
 
-    fun CreateAutoScalingGroupRequest.withKohesiveIdFromName(): CreateAutoScalingGroupRequest = apply {
-        withKohesiveId(this.autoScalingGroupName)
-    }
-
-    fun CreateLaunchConfigurationRequest.withKohesiveIdFromName(): CreateLaunchConfigurationRequest = apply {
-        withKohesiveId(this.launchConfigurationName)
-    }
-
 }
 
 interface AutoScalingEnabled : AutoScalingIdentifiable {
@@ -34,7 +26,7 @@ class AutoScalingContext(private val context: IacContext): AutoScalingEnabled by
     fun AutoScalingContext.createLaunchConfiguration(init: CreateLaunchConfigurationRequest.() -> Unit): CreateLaunchConfigurationResult {
         val launchConfig = CreateLaunchConfigurationRequest().apply {
             init()
-            withKohesiveIdFromName()
+            registerWithAutoName()
         }
         return autoScalingClient.createLaunchConfiguration(launchConfig).apply {
             launchConfigTracking.put(this, launchConfig)
@@ -46,7 +38,7 @@ class AutoScalingContext(private val context: IacContext): AutoScalingEnabled by
     fun AutoScalingContext.createAutoScalingGroup(init: CreateAutoScalingGroupRequest.() -> Unit): CreateAutoScalingGroupResult {
         return autoScalingClient.createAutoScalingGroup(CreateAutoScalingGroupRequest().apply {
             init()
-            withKohesiveIdFromName()
+            registerWithAutoName()
         })
     }
 

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/contexts/AutoScaling.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/contexts/AutoScaling.kt
@@ -27,7 +27,7 @@ class AutoScalingContext(private val context: IacContext): AutoScalingEnabled by
         val launchConfig = CreateLaunchConfigurationRequest().apply {
             this.launchConfigurationName = launchConfigurationName
             this.init()
-            this.withKohesiveIdFromName()
+            this.registerWithAutoName()
         }
         return autoScalingClient.createLaunchConfiguration(launchConfig).apply {
             launchConfigTracking.put(this, launchConfig)
@@ -40,7 +40,7 @@ class AutoScalingContext(private val context: IacContext): AutoScalingEnabled by
         return autoScalingClient.createAutoScalingGroup(CreateAutoScalingGroupRequest().apply {
             this.autoScalingGroupName = autoScalingGroupName
             this.init()
-            this.withKohesiveIdFromName()
+            this.registerWithAutoName()
         })
     }
 

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/contexts/IAM.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/contexts/IAM.kt
@@ -8,17 +8,6 @@ import uy.kohesive.iac.model.aws.utils.DslScope
 
 
 interface IamRoleIdentifiable : KohesiveIdentifiable {
-    fun CreateRoleRequest.withKohesiveIdFromName(): CreateRoleRequest = apply {
-        withKohesiveId(this.roleName)
-    }
-
-    fun CreatePolicyRequest.withKohesiveIdFromName(): CreatePolicyRequest = apply {
-        withKohesiveId(this.policyName)
-    }
-
-    fun CreateInstanceProfileRequest.withKohesiveIdFromName(): CreateInstanceProfileRequest = apply {
-        withKohesiveId(this.instanceProfileName)
-    }
 }
 
 interface IamRoleEnabled : IamRoleIdentifiable {
@@ -31,19 +20,23 @@ interface IamRoleEnabled : IamRoleIdentifiable {
 class IamContext(private val context: IacContext) : IamRoleEnabled by context {
 
     fun IamContext.addRoleToInstanceProfile(init: AddRoleToInstanceProfileRequest.() -> Unit): Unit {
-        iamClient.addRoleToInstanceProfile(AddRoleToInstanceProfileRequest().apply { init(); withKohesiveId(this.roleName + " => " + this.instanceProfileName) })
+        iamClient.addRoleToInstanceProfile(AddRoleToInstanceProfileRequest().apply { init(); registerWithAutoName() })
     }
 
     fun IamContext.createRole(init: CreateRoleRequest.() -> Unit): Role {
-        return iamClient.createRole(CreateRoleRequest().apply { init(); withKohesiveIdFromName() }).role
+        return iamClient.createRole(CreateRoleRequest().apply { init(); registerWithAutoName() }).role
     }
 
     fun IamContext.createPolicy(init: CreatePolicyRequest.() -> Unit): Policy {
-        return iamClient.createPolicy(CreatePolicyRequest().apply { this.init(); withKohesiveIdFromName() }).policy
+        return iamClient.createPolicy(CreatePolicyRequest().apply { this.init(); registerWithAutoName() }).policy
     }
 
     fun IamContext.attachRolePolicy(init: AttachRolePolicyRequest.() -> Unit): Unit {
-        iamClient.attachRolePolicy(AttachRolePolicyRequest().apply { this.init(); withKohesiveId(this.roleName + " => " + this.policyArn) })
+        iamClient.attachRolePolicy(AttachRolePolicyRequest().apply { this.init(); registerWithAutoName() })
+    }
+
+    fun IamContext.createInstanceProfile(init: CreateInstanceProfileRequest.() -> Unit): InstanceProfile {
+        return iamClient.createInstanceProfile(CreateInstanceProfileRequest().apply { this.init(); registerWithAutoName() }).instanceProfile
     }
 
     fun IamContext.attachIamRolePolicy(roleResult: CreateRoleResult, policyResult: CreatePolicyResult): Unit {
@@ -74,7 +67,4 @@ class IamContext(private val context: IacContext) : IamRoleEnabled by context {
         }
     }
 
-    fun createInstanceProfile(init: CreateInstanceProfileRequest.()->Unit): InstanceProfile {
-        return iamClient.createInstanceProfile(CreateInstanceProfileRequest().apply { this.init(); withKohesiveIdFromName() }).instanceProfile
-    }
 }

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/helpers/IAM.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/helpers/IAM.kt
@@ -1,10 +1,9 @@
 package uy.kohesive.iac.model.aws.helpers
 
-import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement
 import com.amazonaws.services.identitymanagement.model.*
-import uy.kohesive.iac.model.aws.IacContext
-import uy.kohesive.iac.model.aws.KohesiveIdentifiable
+import uy.kohesive.iac.model.aws.proxy.KohesiveReference
+import uy.kohesive.iac.model.aws.proxy.isKohesiveRef
 import uy.kohesive.iac.model.aws.utils.writeOnlyVirtualProperty
 
 fun AmazonIdentityManagement.createRole(init: CreateRoleRequest.() -> Unit): CreateRoleResult {
@@ -159,10 +158,17 @@ open class AssumeRolePolicyStatement(val principal: String) : PolicyStatement(Po
 class PolicyDocument<STATEMENT_TYPE : PolicyStatement>(val statements: List<STATEMENT_TYPE>, val version: String = "2012-10-17") : IsReallyJson() {
     override val json: String get() = """
               {
-                  "Version": "${version},
+                  "Version": "${version}",
                   "Statement": [
                      ${statements.map { it.toJson() }.joinToString(",\n")}
                   ]
               }
             """
+}
+
+fun AttachRolePolicyRequest.getPolicyNameFromArn() = if (policyArn.isKohesiveRef()) {
+    KohesiveReference.fromString(policyArn).targetId
+} else {
+    // TODO: implement
+    throw RuntimeException("Can't figure out policy name from ARN")
 }

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/proxy/ProxyUtils.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/proxy/ProxyUtils.kt
@@ -10,29 +10,22 @@ internal object ProxyUtils {
     val INCLUDE_ALL_PROPS: List<KFunction1<Any, Any>> = ArrayList()
 }
 
-internal fun createLiteralReference(ref: String) = "{{kohesive:literal-ref:$ref}}"
-
-inline internal fun <reified T : Any> createReference(targetId: String)
-    = "{{kohesive:ref:${T::class.java.simpleName}:$targetId}}"
-inline internal fun <reified T : Any> createReference(targetId: String, property: String)
-    = "{{kohesive:ref:${T::class.java.simpleName}:$targetId:$property}}"
-
 internal inline fun <S, reified T : Any> makeListProxy(
-        context: IacContext,
-        baseId: String,
-        requestObjects: List<S>,
-        copyFromReq: Map<KFunction1<S, Any>, KFunction1<T, Any>>,
-        includeReferences: List<KFunction1<T, Any>>  = ProxyUtils.INCLUDE_ALL_PROPS,
-        disallowReferences: List<KFunction1<T, Any>> = copyFromReq.values.toList()
+    context: IacContext,
+    baseName: String,
+    requestObjects: List<S>,
+    copyFromReq: Map<KFunction1<S, Any>, KFunction1<T, Any>>,
+    includeReferences: List<KFunction1<T, Any>>  = ProxyUtils.INCLUDE_ALL_PROPS,
+    disallowReferences: List<KFunction1<T, Any>> = copyFromReq.values.toList()
 ): List<T> {
     return requestObjects.mapIndexed { idx, obj ->
-        makeProxy(context, "$baseId[$idx]", obj, copyFromReq, includeReferences, disallowReferences)
+        makeProxy(context, "$baseName[$idx]", obj, copyFromReq, includeReferences, disallowReferences)
     }
 }
 
 internal inline fun <S, reified T : Any> makeProxy(
     context: IacContext,
-    id: String,
+    sourceName: String,
     requestObject: S,
     copyFromReq: Map<KFunction1<S, Any>, KFunction1<T, Any>> = emptyMap(),
     includeReferences: List<KFunction1<T, Any>> = ProxyUtils.INCLUDE_ALL_PROPS,
@@ -40,7 +33,7 @@ internal inline fun <S, reified T : Any> makeProxy(
 ): T {
     return with (context) {
         val delegate = T::class.java.newInstance()
-        (Enhancer.create(T::class.java, MethodInterceptor { obj, method, args, proxy ->
+        (Enhancer.create(T::class.java, MethodInterceptor { _, method, args, _ ->
             copyFromReq.keys.firstOrNull { it.name == method.name }?.let { sourceFunction ->
                 return@MethodInterceptor sourceFunction.invoke(requestObject)
             }
@@ -49,7 +42,7 @@ internal inline fun <S, reified T : Any> makeProxy(
                     throw IllegalArgumentException("${method.name} is disallowed for referencing")
                 } else {
                     if (includeReferences === ProxyUtils.INCLUDE_ALL_PROPS || includeReferences.any { it.name == method.name }) {
-                        return@MethodInterceptor createReference<T>(id, method.name.drop(3))
+                        return@MethodInterceptor createReference<T>(sourceName, method.name.drop(3))
                     } else {
                         throw IllegalArgumentException("${method.name} is disallowed for referencing")
                     }
@@ -57,6 +50,6 @@ internal inline fun <S, reified T : Any> makeProxy(
             } else {
                 return@MethodInterceptor method.invoke(delegate, * args)
             }
-        }) as T).withKohesiveId(id)
+        }) as T).registerWithName(sourceName)
     }
 }

--- a/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/proxy/ReferenceUtil.kt
+++ b/model-aws/src/main/kotlin/uy/kohesive/iac/model/aws/proxy/ReferenceUtil.kt
@@ -1,0 +1,39 @@
+package uy.kohesive.iac.model.aws.proxy
+
+fun String.isKohesiveRef() = startsWith("{{kohesive") && endsWith("}}")
+
+data class KohesiveReference(
+    val refType: String, // ref || literal-ref || var
+    val targetType: String? = null,
+    val targetId: String,
+    val targetProperty: String? = null
+) {
+    companion object {
+        fun fromString(str: String): KohesiveReference {
+            val arr = str.drop("{{kohesive".length).dropLast("}}".length).split(':')
+            if (arr.size < 3) {
+                throw IllegalArgumentException("Not a valid reference: $str")
+            }
+            val refType = arr[1]
+            if (refType == "literal-ref") {
+                return KohesiveReference(refType = refType, targetId = arr[2])
+            }
+            if (refType == "ref") {
+                if (arr.size == 4) {
+                    return KohesiveReference(refType = refType, targetType = arr[2], targetId = arr[3])
+                }
+                if (arr.size == 5) {
+                    return KohesiveReference(refType = refType, targetType = arr[2], targetId = arr[3], targetProperty = arr[4])
+                }
+            }
+            throw IllegalArgumentException("Not a valid reference: $str")
+        }
+    }
+}
+
+internal fun createLiteralReference(ref: String) = "{{kohesive:literal-ref:$ref}}"
+
+inline internal fun <reified T : Any> createReference(targetId: String)
+    = "{{kohesive:ref:${T::class.java.simpleName}:$targetId}}"
+inline internal fun <reified T : Any> createReference(targetId: String, property: String)
+    = "{{kohesive:ref:${T::class.java.simpleName}:$targetId:$property}}"

--- a/model-aws/src/test/kotlin/uy/kohesive/iac/model/aws/proxy/ProxyTest.kt
+++ b/model-aws/src/test/kotlin/uy/kohesive/iac/model/aws/proxy/ProxyTest.kt
@@ -34,7 +34,7 @@ class ProxyTest : TestCase() {
         val instance = result.reservation.instances[0]
 
         // Id
-        assertEquals("MyInstance", context.getId(instance))
+        assertEquals("MyInstance", context.getNameStrict(instance))
 
         // Copied property
         assertEquals("myImageId", instance.imageId)


### PR DESCRIPTION
0. No more kohesiveId, it's called `name` now
1. There's a registry of things that can be auto-named (uy.kohesive.iac.model.aws.AutoNaming)
2. Call `registerWithAutoName` if object (request, response, whatever) can be auto-named
3. The controversial thing — different objects can have same name. I'm not sure if that's ok, let's assume it is. When I build the CloudFormation Template's Resources in `TemplateBuilder#build`, I can just group my objects by a name, and sent that bunch to a Resource Builder.
This allows things that are hard to do otherwise, like listing roles within `AWS::IAM::Policy` (!) because constructing that object actually requires multiple requests — the `CreatePolicyRequest` and at least one `AttachRolePolicyRequest`.

All that allowed me to generate this template:

https://gist.github.com/brainoutsource/f5cc30067d0a3cba405974b6ecf29071

It looks kind of ugly (non context-aware, the typing sucks - no real generics use), but if it's conceptually correct, I can make it prettier.